### PR TITLE
Abort session creation if can't decrypt secrets

### DIFF
--- a/shell-secrets.sh
+++ b/shell-secrets.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 login() {
-  ($(gpg -q --decrypt ~/.shell-secrets/$1.gpg) ; SECRET_LOGIN="$SECRET_LOGIN$1 " bash -l)
+  ($(gpg -q --decrypt ~/.shell-secrets/$1.gpg) && SECRET_LOGIN="$SECRET_LOGIN$1 " bash -l)
 }
 
 _login() {


### PR DESCRIPTION
If `gpg --decrypt` of the secrets fail (due to keys issues, or because the secret doesn't exist, or because the decrypted script exits with an error), avoid creating a new shell session.

**Before:**

```
$ ls -l .shell-secrets/this-doesnt-exist
ls: .shell-secrets/this-doesnt-exist: No such file or directory
$ login this-doesnt-exist
gpg: can't open '/Users/mgarcia/.shell-secrets/this-doesnt-exist.gpg': No such file or directory
gpg: decrypt_message failed: No such file or directory
this-doesnt-exist $ # ?!?!??!
```

**After:**

```
$ ls -l .shell-secrets/this-doesnt-exist
ls: .shell-secrets/this-doesnt-exist: No such file or directory
$ login this-doesnt-exist
gpg: can't open '/Users/mgarcia/.shell-secrets/this-doesnt-exist.gpg': No such file or directory
gpg: decrypt_message failed: No such file or directory
$ # same bash process as before
```